### PR TITLE
Move eslint dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,7 @@
     "babel-core": "^6.16.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
-    "mocha": "^3.1.2"
-  },
-  "optionalDependencies": {
+    "mocha": "^3.1.2",
     "eslint": "^3.7.0",
     "eslint-config-standard": "^6.2.0",
     "eslint-plugin-promise": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -41,14 +41,15 @@
     "astronomia": "^1.1.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.16.0",
     "babel-preset-es2015": "^6.16.0",
     "babel-register": "^6.16.3",
-    "mocha": "^3.1.2",
     "eslint": "^3.7.0",
     "eslint-config-standard": "^6.2.0",
     "eslint-plugin-promise": "^3.3.0",
-    "eslint-plugin-standard": "^2.0.1"
+    "eslint-plugin-standard": "^2.0.1",
+    "mocha": "^3.1.2"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-config-standard": "^6.2.0",
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1",
+    "istanbul": "^0.4.5",
     "mocha": "^3.1.2"
   },
   "babel": {

--- a/src/Vietnamese.js
+++ b/src/Vietnamese.js
@@ -14,9 +14,9 @@ class CalendarVietnamese extends CalendarChinese {
    */
   timeshiftUTC (gcal) {
     if (gcal.toYear() >= 1968) {
-      return 7 / 24		// +7:00:00h
+      return 7 / 24 // +7:00:00h
     }
-    return 8 / 24   	// +8:00:00h Standard China time zone (120° East)
+    return 8 / 24 // +8:00:00h Standard China time zone (120° East)
   }
 }
 module.exports = CalendarVietnamese


### PR DESCRIPTION
This will prevent older versions of eslint being installed when depending on this package. Even though eslint is defined as an optional dependency, it is being installed by default.

Also, fixed linting errors, added bable-cli to allow transpile and added istanbul to run coverage.